### PR TITLE
Rewrite README to describe the site and fix theme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,27 @@
-Aerial by HTML5 UP
-html5up.net | @ajlkn
-Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+# Personal Website
 
-### Change Mode of website (Light or Dark)
+Kevin Todd's personal website — a single-page landing site that points visitors to
+my GitHub and LinkedIn. Built as a static site with heavy use of CSS animation
+(animated tagline, drawn divider, and a drifting Midnight + Cyan gradient background).
 
-#### Dark Mode
-	rename /personal_website/assets/css/main.css to main_light.css
-	rename /personal_website/assets/css/main_dark.css to main.css
+## Theme (Dark / Light)
 
-#### Light Mode
-	rename /personal_website/assets/css/main.css to main_dark.css
-	rename /personal_website/assets/css/main_light.css to main.css
+The active stylesheet is `assets/css/main.css`. The site ships with the dark
+(Midnight + Cyan) theme active, and an alternate light theme in
+`assets/css/main_light.css`.
 
-This is Aerial, a single page, single screen responsive site template. Real simple.
-Makes heavy use of CSS animation (something I've been messing with a lot lately).
-Should work well as a landing page that just directs folks to your stuff elsewhere
-on the www. Sass sources are also included, so if you've never used Sass and you're
-interested in giving it a try, head on over to sass-lang.com (and if not, you can
-safely delete the "sass/" folder).
+To switch to the light theme, swap the two files:
 
-The scrolling mountainous background was derived from "Icefields" by Ryan Schroeder,
-a talented photographer from Vancouver who graciously released it on Unsplash under
-the CC0 license. Be sure to check out his other stuff over at flickr (link below)
-as well as all the other kickass CC0-licensed images at Unsplash (unsplash.com).
+    rename assets/css/main.css        -> main_dark.css
+    rename assets/css/main_light.css  -> main.css
 
-Questions/comments/issues = just email or find me on Twitter. Have fun!
+(and reverse it to go back to dark).
 
-AJ
-aj@lkn.io | @ajlkn
+## Credits
 
+This site is based on the **Aerial** template by HTML5 UP
+(html5up.net | @ajlkn), used under the
+[CCA 3.0 license](https://html5up.net/license). The original scrolling
+background has since been replaced with a custom animated gradient.
 
-The Scrolling Background:
-
-	This relies entirely on CSS to do its thing, which is cool, but that makes
-	changing it a bit weird/tricky at first. You can still use pretty much any image
-	you want, but for best results make sure yours is:
-
-	- Horizontally tileable.
-	- Wide and short.
-	- About 1500px wide.
-	- Fades to a solid color either at the top of bottom (which is used to fill
-	  the empty space above or below your image).
-
-	Now, there are two ways to use it: with CSS, or with Sass:
-
-	CSS:
-
-		Look for this line in css/style.css (line 108 as of this writing):
-
-			background: #348cb2 url("images/bg.jpg") bottom left;
-
-		and use it to set the page background color, URL, and placement of
-		your image. It should be as close to 1500px wide as you can get it.
-
-	Sass:
-
-		Set the value of $bg to the page background color, URL, and placement
-		of your image. Change $bg-width if your image is something other than
-		1500px wide.
-
-
-Credits:
-
-	Background Image:
-		Ryan Schroeder via Unsplash (unsplash.com - CC0 licensed)
-			"Icefields" (flickr.com/photos/ryanschroeder/11876741703)
-
-	Icons:
-		Font Awesome (fontawesome.io)
-
-	Other:
-		Responsive Tools (github.com/ajlkn/responsive-tools)
+Icons by [Font Awesome](https://fontawesome.io).


### PR DESCRIPTION
Replaces the leftover HTML5 UP "Aerial" boilerplate README with one that describes the actual site, and corrects the dark/light theme instructions (the old README referenced `main_dark.css`, which no longer exists — `main.css` is the active dark theme, `main_light.css` is the alternate). Keeps the required HTML5 UP attribution and CCA 3.0 license note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)