### PR TITLE
Add dynamic copyright footer

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -800,6 +800,7 @@ input, select, textarea {
 		background-image: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.5) 75%);
 		bottom: 0;
 		cursor: default;
+		font-size: 0.75em;
 		height: 6em;
 		left: 0;
 		line-height: 8em;

--- a/index.html
+++ b/index.html
@@ -42,15 +42,17 @@
 						</nav>
 					</header>
 
-				<!-- Footer 
+				<!-- Footer -->
 					<footer id="footer">
-						<span class="copyright">&copy; Untitled. Design: <a href="http://html5up.net">HTML5 UP</a>.</span>
+						<span class="copyright">&copy; <span id="year"></span> All rights reserved. Kevin Todd</span>
 					</footer>
-				-->
 			</div>
 		</div>
 		<script>
-			window.onload = function() { document.body.classList.remove('is-preload'); }
+			window.onload = function() {
+				document.body.classList.remove('is-preload');
+				document.getElementById('year').textContent = new Date().getFullYear();
+			}
 			window.ontouchmove = function() { return false; }
 			window.onorientationchange = function() { document.body.scrollTop = 0; }
 		</script>


### PR DESCRIPTION
## Summary
- Uncomments the existing (previously hidden) footer element
- Updates the copyright text to "© [year] All rights reserved. Kevin Todd"
- Year is set dynamically via `new Date().getFullYear()` on page load, so it updates automatically each January 1st
- Adds `font-size: 0.75em` to `#footer` CSS for small-print styling

## Test plan
- [ ] Open the site and confirm the copyright notice appears at the bottom
- [ ] Verify the year matches the current year
- [ ] Confirm text is visibly smaller than the main body copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VASgDQ4kDLz5u4UawfQNZz