### PR TITLE
Tone down footer copyright text

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -800,7 +800,8 @@ input, select, textarea {
 		background-image: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.5) 75%);
 		bottom: 0;
 		cursor: default;
-		font-size: 0.75em;
+		color: #888;
+		font-size: 0.6em;
 		height: 6em;
 		left: 0;
 		line-height: 8em;


### PR DESCRIPTION
## Summary
- Reduces footer font size from `0.75em` to `0.6em`
- Sets footer text color to `#888` (medium gray) instead of inheriting bright white

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VASgDQ4kDLz5u4UawfQNZz