### PR TITLE
Darken footer copyright text to #555

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -800,7 +800,7 @@ input, select, textarea {
 		background-image: linear-gradient(top, rgba(0,0,0,0), rgba(0,0,0,0.5) 75%);
 		bottom: 0;
 		cursor: default;
-		color: #888;
+		color: #555;
 		font-size: 0.6em;
 		height: 6em;
 		left: 0;


### PR DESCRIPTION
## Summary
- Changes footer text color from `#888` to `#555` — the previous value read as near-white against the dark background; this produces a clearly gray appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VASgDQ4kDLz5u4UawfQNZz