### PR TITLE
Increase footer font size to 0.7em

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -801,7 +801,7 @@ input, select, textarea {
 		bottom: 0;
 		cursor: default;
 		color: #555;
-		font-size: 0.6em;
+		font-size: 0.7em;
 		height: 6em;
 		left: 0;
 		line-height: 8em;


### PR DESCRIPTION
## Summary
- Bumps footer copyright font size from `0.6em` to `0.7em`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VASgDQ4kDLz5u4UawfQNZz